### PR TITLE
fix: Authn plugin revert to master

### DIFF
--- a/src/dt-tutor-devsetup/tutordevsetup/plugin.py
+++ b/src/dt-tutor-devsetup/tutordevsetup/plugin.py
@@ -13,7 +13,7 @@ config = {
             "name": "auth",
             "port": 1999,
             "repository": "https://github.com/Dicey-Tech/frontend-app-authn",
-            "version": "develop",
+            "version": "master",
             "env": {
                 "production": {
                     "DISABLE_ENTERPRISE_LOGIN": "true",


### PR DESCRIPTION
The master works just fine with latest components so use it instead of develop.